### PR TITLE
Switch imported_libs.cmake to NAME_WE to stay compliant with cmake 3.10

### DIFF
--- a/third_party/silabs/cmake/imported_libs.cmake
+++ b/third_party/silabs/cmake/imported_libs.cmake
@@ -35,7 +35,7 @@ file(GLOB rail_libs ${librail_release_dir}/*.a)
 foreach(lib_file ${rail_libs})
 
     # Parse lib name, stripping .a extension
-    get_filename_component(lib_name ${lib_file} NAME_WLE)
+    get_filename_component(lib_name ${lib_file} NAME_WE)
     set(imported_lib_name "silabs-${lib_name}")
 
     # Add as an IMPORTED lib
@@ -58,7 +58,7 @@ file(GLOB nvm3_libs ${libnvm3_release_dir}/*.a)
 foreach(lib_file ${nvm3_libs})
 
     # Parse lib name, stripping .a extension
-    get_filename_component(lib_name ${lib_file} NAME_WLE)
+    get_filename_component(lib_name ${lib_file} NAME_WE)
     set(imported_lib_name "silabs-${lib_name}")
 
     # Add as an IMPORTED lib


### PR DESCRIPTION
Also, update openthread commit to HEAD of  `main`

Otherwise, this PR is the same as **https://github.com/openthread/openthread/pull/6328**
