### PR TITLE
Update README.md

### DIFF
--- a/src/efr32mg12/README.md
+++ b/src/efr32mg12/README.md
@@ -22,6 +22,7 @@ In a Bash terminal, follow these instructions to install the GNU toolchain and o
 
 ```bash
 $ cd <path-to-ot-efr32>
+$ git submodule update --init
 $ ./script/bootstrap
 ```
 
@@ -32,7 +33,6 @@ the build may be launched using `./script/build`
 
 ```bash
 $ cd <path-to-ot-efr32>
-$ git submodule update --init
 $ ./script/build efr32mg12 -DBOARD=brd4161a
 ...
 -- Configuring done


### PR DESCRIPTION
In Toolchain chapter, it will report the following error if run ./script/bootstrap.
//////////////////////////////////////////
pi@raspberrypi:~ $ cd ot-efr32/
pi@raspberrypi:~/ot-efr32 $ ./script/bootstrap
++ dirname ./script/bootstrap
+ ./script/../openthread/script/bootstrap
./script/bootstrap: line 32: ./script/../openthread/script/bootstrap: No such file or directory
//////////////////////////////////////////