### PR TITLE
Support for ot-rcp-spi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 
 # RCP platform library
 if(NOT OT_PLATFORM_LIB_RCP)
-    set(OT_PLATFORM_LIB_RCP "openthread-efr32-rcp" CACHE STRING "default efr32 RCP platform library" FORCE)
+    set(OT_PLATFORM_LIB_RCP "openthread-efr32-rcp-uart" CACHE STRING "default efr32 RCP platform library" FORCE)
 endif()
 
 set(OT_PLATFORM "external" CACHE STRING "disable example platforms" FORCE)
@@ -81,7 +81,7 @@ set(OT_MBEDTLS ${OT_EXTERNAL_MBEDTLS})
 
 # RCP mbedtls library
 if(NOT OT_MBEDTLS_RCP)
-    set(OT_MBEDTLS_RCP "openthread-efr32-rcp-mbedtls" CACHE STRING "default efr32 RCP mbedtls library" FORCE)
+    set(OT_MBEDTLS_RCP "openthread-efr32-rcp-uart-mbedtls" CACHE STRING "default efr32 RCP mbedtls library" FORCE)
 endif()
 
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "disable builtin mbedtls management" FORCE)
@@ -110,8 +110,13 @@ message("OT_APP_RCP = ${OT_APP_RCP}")
 message("OT_APP_NCP = ${OT_APP_NCP}")
 message("OT_APP_CLI = ${OT_APP_CLI}")
 if(OT_APP_RCP)
-    message("Adding ${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp")
-    add_subdirectory(${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp)
+    if(OT_NCP_SPI)
+        message("Adding ${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_spi")
+        add_subdirectory(${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_spi)
+    else()
+        message("Adding ${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_uart")
+        add_subdirectory(${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_uart)
+    endif()
 elseif(OT_APP_NCP OR OT_APP_CLI)
     message("Adding ${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/soc")
     add_subdirectory(${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/soc)

--- a/script/build
+++ b/script/build
@@ -98,17 +98,17 @@ generate()
         mv "${current_project_export_dir}/${project_name}.Makefile" "${current_project_export_dir}/CMakeLists.txt"
         mv "${current_project_export_dir}/${project_name}.project.mak" "${current_project_export_dir}/${project_name}-mbedtls.cmake"
     fi
-    if contains "ot-rcp" "${OT_CMAKE_NINJA_TARGET[@]}"; then
+    if contains "ot-rcp-uart" "${OT_CMAKE_NINJA_TARGET[@]}"; then
         # ==============================================================================================================
-        # Generate openthread-efr32-rcp and openthread-efr32-rcp-mbedtls libs
+        # Generate openthread-efr32-rcp-uart and openthread-efr32-rcp-uart-mbedtls libs
         # ==============================================================================================================
-        current_project_export_dir="${slc_generated_projects_dir}/rcp"
-        project_name="openthread-efr32-rcp"
+        current_project_export_dir="${slc_generated_projects_dir}/rcp_uart"
+        project_name="openthread-efr32-rcp-uart"
 
         run_slc -v 1 generate \
             --sdk="${sdk_dir}" \
             --clear-cache \
-            --project-file="${repo_dir}/src/platform_projects/openthread-efr32-rcp.slcp" \
+            --project-file="${repo_dir}/src/platform_projects/${project_name}.slcp" \
             --project-name="${project_name}" \
             --output-type=makefile \
             --no-copy \
@@ -119,6 +119,40 @@ generate()
         # TODO: Remove this when slc supports generic jinja template generation
         mv "${current_project_export_dir}/${project_name}.Makefile" "${current_project_export_dir}/CMakeLists.txt"
         mv "${current_project_export_dir}/${project_name}.project.mak" "${current_project_export_dir}/${project_name}-mbedtls.cmake"
+    fi
+    if contains "ot-rcp-spi" "${OT_CMAKE_NINJA_TARGET[@]}"; then
+        # ==============================================================================================================
+        # Generate openthread-efr32-rcp-spi and openthread-efr32-rcp-spi-mbedtls libs
+        # ==============================================================================================================
+        current_project_export_dir="${slc_generated_projects_dir}/rcp_spi"
+        project_name="openthread-efr32-rcp-spi"
+        local silabs_dir="${repo_dir}"/third_party/silabs
+
+        # Apply patch(es) to gecko_sdk for rcp-spi libs
+        echo "Applying patch(es) to Gecko SDK..."
+        cd "${silabs_dir}"/gecko_sdk
+        # Read the tag to restore the gecko_sdk head back to original
+        tag=$(git describe --tag)
+        git apply "${silabs_dir}"/patches/*.patch
+
+        run_slc -v 1 generate \
+            --sdk="${sdk_dir}" \
+            --clear-cache \
+            --project-file="${repo_dir}/src/platform_projects/${project_name}.slcp" \
+            --project-name="${project_name}" \
+            --output-type=makefile \
+            --no-copy \
+            --export-templates="${repo_dir}"/third_party/silabs/slc/exporter_templates/platform_library \
+            --export-destination="${current_project_export_dir}" \
+            --with "${board}"
+
+        # TODO: Remove this when slc supports generic jinja template generation
+        mv "${current_project_export_dir}/${project_name}.Makefile" "${current_project_export_dir}/CMakeLists.txt"
+        mv "${current_project_export_dir}/${project_name}.project.mak" "${current_project_export_dir}/${project_name}-mbedtls.cmake"
+
+        echo "Restoring gecko_sdk back to tag ${tag}."
+        cd "${silabs_dir}"/gecko_sdk
+        git reset --hard "${tag}"
     fi
 }
 
@@ -135,9 +169,9 @@ create_srec()
     find "$1" -type f "${executable_flag[@]}" -not -name '*.*' -exec arm-none-eabi-objcopy -O srec {} {}.s37 \; -exec ls -alh {} {}.s37 \;
 }
 
-build_rcp()
+build_rcp_uart()
 {
-    builddir="${OT_CMAKE_BUILD_DIR:-$repo_dir/build/${board}}/openthread/rcp"
+    builddir="${OT_CMAKE_BUILD_DIR:-$repo_dir/build/${board}}/openthread/rcp_uart"
 
     mkdir -p "${builddir}"
     cd "${builddir}"
@@ -151,10 +185,40 @@ build_rcp()
         -DOT_APP_NCP=OFF \
         -DOT_APP_RCP=ON \
         -DOT_COMPILE_WARNING_AS_ERROR=ON \
+        -DOT_PLATFORM_LIB_RCP="openthread-efr32-rcp-uart" \
+        -DOT_MBEDTLS_RCP="openthread-efr32-rcp-uart-mbedtls" \
         "$@" "${repo_dir}" \
         --graphviz=graph.dot
 
-    ninja "${rcp_targets[@]}"
+    ninja "ot-rcp"
+
+    create_srec "${builddir}"
+    cd "${repo_dir}"
+}
+
+build_rcp_spi()
+{
+    builddir="${OT_CMAKE_BUILD_DIR:-$repo_dir/build/${board}}/openthread/rcp_spi"
+
+    mkdir -p "${builddir}"
+    cd "${builddir}"
+
+    cmake \
+        -GNinja \
+        -DOT_FTD=OFF \
+        -DOT_MTD=OFF \
+        -DOT_RCP=ON \
+        -DOT_APP_CLI=OFF \
+        -DOT_APP_NCP=OFF \
+        -DOT_APP_RCP=ON \
+        -DOT_COMPILE_WARNING_AS_ERROR=ON \
+        -DOT_NCP_SPI=ON \
+        -DOT_PLATFORM_LIB_RCP="openthread-efr32-rcp-spi" \
+        -DOT_MBEDTLS_RCP="openthread-efr32-rcp-spi-mbedtls" \
+        "$@" "${repo_dir}" \
+        --graphviz=graph.dot
+
+    ninja "ot-rcp"
 
     create_srec "${builddir}"
     cd "${repo_dir}"
@@ -250,10 +314,10 @@ main()
 
     case "${platform}" in
         efr32mg1)
-            OT_CMAKE_NINJA_TARGET=("ot-rcp")
+            OT_CMAKE_NINJA_TARGET=("ot-rcp-uart")
             ;;
         efr32mg12 | efr32mg13 | efr32mg21 | efr32mg24)
-            OT_CMAKE_NINJA_TARGET=("ot-rcp" "ot-cli-ftd" "ot-cli-mtd" "ot-ncp-ftd" "ot-ncp-mtd")
+            OT_CMAKE_NINJA_TARGET=("ot-rcp-uart" "ot-rcp-spi" "ot-cli-ftd" "ot-cli-mtd" "ot-ncp-ftd" "ot-ncp-mtd")
             if [ "${skip_silabs_apps}" = false ]; then
 
                 if [ "${skip_generation}" = true ]; then
@@ -279,9 +343,14 @@ main()
     soc_targets=()
     for t in "${OT_CMAKE_NINJA_TARGET[@]}"; do [[ $t =~ .*rcp.* ]] && rcp_targets+=("$t") || soc_targets+=("$t"); done
 
-    if [ ! ${#rcp_targets[@]} -eq 0 ]; then
-        build_rcp -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
+    # Build ot-rcp targets
+    if contains "ot-rcp-uart" "${rcp_targets[@]}"; then
+        build_rcp_uart -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
     fi
+    if contains "ot-rcp-spi" "${rcp_targets[@]}"; then
+        build_rcp_spi -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
+    fi
+    # Build soc targets
     if [ ! ${#soc_targets[@]} -eq 0 ]; then
         build_soc -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
     fi

--- a/src/platform_projects/openthread-efr32-rcp-spi.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-spi.slcp
@@ -1,0 +1,22 @@
+project_name: openthread-efr32-rcp-spi
+label: ot-efr32
+package: OpenThread
+description: This is the platform project that will enable the ot-efr32 repo on GitHub to generate a CMake library for EFR32 RCPs which communicate over SPI.
+category: OpenThread Examples
+quality: production
+
+component:
+  - id: ot_platform_abstraction_core
+  - id: ot_thirdparty
+  - id: ot_ncp_spidrv
+  - id: rail_util_pti
+
+configuration:
+  - name: SL_BOARD_ENABLE_VCOM
+    value: 1
+
+define:
+  - name: OPENTHREAD_COPROCESSOR
+    value: 1
+  - name: OPENTHREAD_RADIO
+    value: 1

--- a/src/platform_projects/openthread-efr32-rcp-uart.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-uart.slcp
@@ -1,12 +1,11 @@
-project_name: openthread-efr32-rcp
+project_name: openthread-efr32-rcp-uart
 label: ot-efr32
 package: OpenThread
-description: This is the platform project that will enable the ot-efr32 repo on GitHub to generate a CMake library for EFR32 RCPs
+description: This is the platform project that will enable the ot-efr32 repo on GitHub to generate a CMake library for EFR32 RCPs which communicate over UART interface.
 category: OpenThread Examples
 quality: production
 
 component:
-  - id: brd4001a
   - id: ot_platform_abstraction_core
   - id: ot_thirdparty
   - id: uartdrv_usart

--- a/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
@@ -7,7 +7,6 @@ category: OpenThread Examples
 quality: production
 
 component:
-  - id: brd4001a
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_thirdparty

--- a/src/platform_projects/openthread-efr32-soc.slcp
+++ b/src/platform_projects/openthread-efr32-soc.slcp
@@ -6,7 +6,6 @@ category: OpenThread Examples
 quality: production
 
 component:
-  - id: brd4001a
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_thirdparty

--- a/src/src/spidrv_usart.c
+++ b/src/src/spidrv_usart.c
@@ -54,10 +54,10 @@
 
 #include "sl_ncp_spidrv_usart_config.h"
 
-#include "error.h"
 #include "openthread-system.h"
 #include "platform-efr32.h"
 #include "spi-slave.h"
+#include <openthread/error.h>
 #include "utils/code_utils.h"
 
 // DEFINES

--- a/third_party/silabs/patches/0001-Remove-stack-components-to-prevent-adding-OpenThread.patch
+++ b/third_party/silabs/patches/0001-Remove-stack-components-to-prevent-adding-OpenThread.patch
@@ -1,0 +1,26 @@
+diff --git a/protocol/openthread/component/ot_ncp_spidrv.slcc b/protocol/openthread/component/ot_ncp_spidrv.slcc
+index a7e77bd97329..c2eb8a26ae83 100644
+--- a/protocol/openthread/component/ot_ncp_spidrv.slcc
++++ b/protocol/openthread/component/ot_ncp_spidrv.slcc
+@@ -7,8 +7,8 @@ description: This component provides SPIDRV (SPI) support for the OpenThread sta
+ provides:
+   - name: ot_ncp_spidrv
+ requires:
+-  - name: ot_stack
+-  - name: ot_ncp
++  #- name: ot_stack
++  #- name: ot_ncp
+   - name: gpiointerrupt
+   - name: emlib_ldma
+   - name: spidrv_core
+@@ -25,8 +25,8 @@ config_file:
+   - path: protocol/openthread/config/ot_ncp_spidrv/s2/sl_ncp_spidrv_usart_config.h
+     file_id: sl_ncp_spidrv_usart_config
+     condition: [device_series_2]
+-recommends:
+-  - id: ot_stack_rcp
++#recommends:
++#  - id: ot_stack_rcp
+ define:
+   - name: OPENTHREAD_CONFIG_NCP_HDLC_ENABLE
+     value: 0


### PR DESCRIPTION
- Add a new project file (openthread-efr32-rcp-spi.slcp) to generate openthread-efr32-rcp-spi and openthread-efr32-rcp-spi-mbedtls libs.
- Add a patch file to apply over gecko_sdk for ot-rcp-spi target to generate libs and reset head back after generation.
- Update build script to build 'ot-rcp-spi' image.
- Re-organize build directories to compile UART and SPI ot-rcp targets into respective dirs.