### PR TITLE
[script] leverage `slc` SDK cache and add `ccache` to speedup incremental builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,11 @@ jobs:
           key: ${{ matrix.gcc_ver }}
           verbose: 2
 
+      - name: Append LFS include config to GSDK .lfsconfig
+        run: |
+          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
+          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a,protocol/openthread/libs/libsl_openthread_efr32mg*x_gcc.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
+
       - name: Create LFS file hash list
         run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,23 +78,15 @@ jobs:
           key: ${{ matrix.gcc_ver }}
           verbose: 2
 
-      - name: Append LFS include config to GSDK .lfsconfig
-        run: |
-          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
-          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a,protocol/openthread/libs/libsl_openthread_efr32mg*x_gcc.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
-
-      - name: Create LFS file hash list
-        run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore gecko_sdk LFS cache
+      - name: Restore ARM Toolchain
         uses: actions/cache@v4
-        id: lfs-cache
+        id: cache-arm-toolchain
         with:
-            path: .git/modules/third_party/silabs/gecko_sdk/lfs
-            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+            path: ${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}
+            key: ${{ matrix.gcc_extract_dir }}
 
-      - name: Git LFS Pull
-        run: git -C third_party/silabs/gecko_sdk lfs pull
+      - name: Bootstrap ARM Toolchain
+        run: script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
 
       - name: Download Docker image
         uses: actions/download-artifact@v4
@@ -114,8 +106,23 @@ jobs:
             -v $PWD:/ot-efr32 -w /ot-efr32\
             ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
-      - name: Bootstrap ARM Toolchain
-        run: docker exec ot-efr32-dev script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
+      - name: Append LFS include config to GSDK .lfsconfig
+        run: |
+          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
+          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a,protocol/openthread/libs/libsl_openthread_efr32mg*x_gcc.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
+
+      - name: Create LFS file hash list
+        run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore gecko_sdk LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache-gecko_gsdk
+        with:
+            path: .git/modules/third_party/silabs/gecko_sdk/lfs
+            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: git -C third_party/silabs/gecko_sdk lfs pull
 
       - name: Build
         run: docker exec ot-efr32-dev bash -c 'PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH script/test'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           submodules: true
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.gcc_ver }}
+          verbose: 2
+
       - name: Create LFS file hash list
         run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
@@ -94,7 +100,14 @@ jobs:
         run: docker load -i ot-efr32-dev.tar
 
       - name: Start ot-efr32-dev container
-        run: docker run --rm -it --user $(id -u) --name ot-efr32-dev -d -v $PWD:/ot-efr32 -w /ot-efr32 ${{ env.DOCKER_IMAGE_SHA_TAG }}
+        run: |
+          docker run \
+            --rm -it -d \
+            --user $(id -u) \
+            --name ot-efr32-dev \
+            --env CCACHE_DIR=/ot-efr32/.ccache \
+            -v $PWD:/ot-efr32 -w /ot-efr32\
+            ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
       - name: Bootstrap ARM Toolchain
         run: docker exec ot-efr32-dev script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
+env:
+  TOOLCHAIN_DIR: .toolchain
+  DOCKER_IMAGE_SHA_TAG: siliconlabsinc/ot-efr32-dev:${{ github.sha }}
+
 jobs:
+  docker:
+    name: Docker
+    uses: ./.github/workflows/docker.yml
+
   arm-gcc:
-    name: arm-gcc-${{ matrix.gcc_ver }}
+    name: Arm GNU Toolchain ${{ matrix.gcc_ver }}
     runs-on: ubuntu-22.04
-    container:
-      image: siliconlabsinc/ot-efr32-dev:latest
-      options: --user 1001
+    needs: docker
+    continue-on-error: true
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -59,46 +68,54 @@ jobs:
             gcc_extract_dir: arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Create LFS file hash list
-      run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Create LFS file hash list
+        run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
-    - name: Restore gecko_sdk LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
-      with:
-          path: .git/modules/third_party/silabs/gecko_sdk/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+      - name: Restore gecko_sdk LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+            path: .git/modules/third_party/silabs/gecko_sdk/lfs
+            key: lfs-${{ hashFiles('.lfs-assets-id') }}
 
-    - name: Git LFS Pull
-      run: git -C third_party/silabs/gecko_sdk lfs pull
+      - name: Git LFS Pull
+        run: git -C third_party/silabs/gecko_sdk lfs pull
 
-    - name: Bootstrap ARM Toolchain
-      run: |
-        script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }}
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: ot-efr32-dev
 
-    - name: Build
-      run: |
-        export PATH=${HOME}/.local/${{ matrix.gcc_extract_dir }}/bin:$PATH
-        script/test
+      - name: Load docker image
+        run: docker load -i ot-efr32-dev.tar
 
-    - name: Gather SLC generated files
-      if: failure()
-      run: |
-        rm -rf artifact && mkdir artifact
-        for b in build/*/slc; do
-            board=$(basename $(dirname "${b}"))
+      - name: Start ot-efr32-dev container
+        run: docker run --rm -it --user $(id -u) --name ot-efr32-dev -d -v $PWD:/ot-efr32 -w /ot-efr32 ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
-            echo "Artifacting '${board}'"
-            mkdir -p "artifact/${board}"
-            mv "build/${board}/slc" "artifact/${board}"
-        done
+      - name: Bootstrap ARM Toolchain
+        run: docker exec ot-efr32-dev script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
 
-    - uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: build-${{ matrix.gcc_ver }}
-        path: artifact
+      - name: Build
+        run: docker exec ot-efr32-dev bash -c 'PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH script/test'
+
+      - name: Gather SLC generated files
+        if: failure()
+        run: |
+          rm -rf artifact && mkdir artifact
+          for b in build/*/slc; do
+              board=$(basename $(dirname "${b}"))
+
+              echo "Artifacting '${board}'"
+              mkdir -p "artifact/${board}"
+              mv "build/${board}/slc" "artifact/${board}"
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: build-${{ matrix.gcc_ver }}
+          path: artifact

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,57 +28,53 @@
 
 name: Docker
 
-env:
-  TEST_TAG: siliconlabsinc/ot-efr32-dev:test
-  SHA_TAG: siliconlabsinc/ot-efr32-dev:${{ github.sha }}
-  LATEST_TAG: siliconlabsinc/ot-efr32-dev:latest
-
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-  pull_request:
-    branches:
-      - 'main'
+  workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
-  cancel-in-progress: true
-
-permissions:  # added using https://github.com/step-security/secure-workflows
-  contents: read
+env:
+  DOCKER_IMAGE_SHA_TAG: siliconlabsinc/ot-efr32-dev:${{ github.sha }}
+  DOCKER_IMAGE_LATEST_TAG: siliconlabsinc/ot-efr32-dev:latest
 
 jobs:
+  metadata:
+    uses: ./.github/workflows/metadata.yml
+
   build:
-    name: Build Docker Image
+    name: Build
     runs-on: ubuntu-22.04
+    needs: metadata
+    permissions:
+      contents: read
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-    - uses: actions/checkout@v4 # v3.3.0
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         submodules: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+      with:
+        platforms: linux/amd64
 
     - name: Build and export to Docker context
       uses: docker/build-push-action@v6
       with:
+        build-args: |
+          BUILD_DATE=${{ needs.metadata.outputs.date }}
         context: .
         file: docker/Dockerfile
         load: true
-        build-args: |
-          - BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        platforms:
-          linux/amd64
         tags: |
-          ${{ env.TEST_TAG }}
+          ${{ env.DOCKER_IMAGE_SHA_TAG }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Inspect Docker image
+      run: docker inspect ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
     - name: Container image sanity checks
       run: |
@@ -87,49 +83,45 @@ jobs:
           && chmod +x container-structure-test-linux-amd64
 
         # Run tests
-        ./container-structure-test-linux-amd64 test --config docker/test-ot-efr32-dev.yml --image ${{ env.TEST_TAG }}
+        ./container-structure-test-linux-amd64 test --config docker/test-ot-efr32-dev.yml --image ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
-    - name: Create LFS file hash list
-      run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+    - name: Export Docker image
+      run: docker save -o ot-efr32-dev.tar ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
-    - name: Restore gecko_sdk LFS cache
-      uses: actions/cache@v4
-      id: lfs-cache
+    - name: Upload Docker image
+      uses: actions/upload-artifact@v4
       with:
-          path: .git/modules/third_party/silabs/gecko_sdk/lfs
-          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+        name: ot-efr32-dev
+        path: ot-efr32-dev.tar
 
-    - name: Git LFS Pull
-      run: git -C third_party/silabs/gecko_sdk lfs pull
+  publish-dockerhub:
+    name: Tag `latest` and publish to DockerHub
+    runs-on: ubuntu-22.04
+    needs: [metadata, build]
+    if: |
+      github.repository == 'SiliconLabs/ot-efr32' &&
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main'
+    steps:
+      - name: Login to DockerHub
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3.2.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Test build inside container
-      run: |
-        docker run -v ${{ github.workspace }}:/ot-efr32/ --user $(id -u) --rm ${{ env.TEST_TAG }} script/build --skip-silabs-apps brd4151a
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: ot-efr32-dev
 
-    - name: Login to DockerHub
-      uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
-      if: |
-        success() &&
-        github.repository == 'SiliconLabs/ot-efr32' &&
-        github.event_name != 'pull_request' &&
-        github.ref == 'refs/heads/main'
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Load Docker image
+        run: docker load -i ot-efr32-dev.tar
 
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      if: |
-        success() &&
-        github.repository == 'SiliconLabs/ot-efr32' &&
-        github.event_name != 'pull_request' &&
-        github.ref == 'refs/heads/main'
-      with:
-        context: .
-        file: docker/Dockerfile
-        push: true
-        tags: |
-          ${{ env.LATEST_TAG }}
-          ${{ env.SHA_TAG }}
-        platforms:
-          linux/amd64
+      - name: Tag Docker image
+        run: |
+          docker tag ${{ env.DOCKER_IMAGE_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }}
+
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.DOCKER_IMAGE_LATEST_TAG }}

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,0 +1,55 @@
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Metadata
+
+on:
+  workflow_call:
+    outputs:
+      owner:
+        description: 'The lowercase GitHub repository owner'
+        value: ${{ jobs.metadata.outputs.owner }}
+      date:
+        description: 'The current date'
+        value: ${{ jobs.metadata.outputs.date }}
+
+jobs:
+  metadata:
+    name: Generate required metadata
+    runs-on: ubuntu-22.04
+    outputs:
+      owner: ${{ steps.lowercase_owner.outputs.owner }}
+      date: ${{ steps.date.outputs.date }}
+    steps:
+      - name: Lowercase GitHub repository owner
+        id: lowercase_owner
+        run: echo "owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_OUTPUT}
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_OUTPUT}
+

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,9 @@ __pycache__
 .history/
 
 # slc-cli
+?/
 slc/slc_cli/
 slc/**/*.zip
 
 .cache
+.toolchain

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE='ubuntu:22.04'
+
+FROM ${BASE_IMAGE} AS base
 
 ENV TZ="America/New_York"
 ENV repo_dir="/ot-efr32"
@@ -23,7 +25,11 @@ RUN ./script/bootstrap arm_toolchain
 COPY ./requirements.txt .
 RUN ./script/bootstrap python
 
+# ==============================================================================
+
 # Label the build date before downloading slc to force slc to always be downloaded during a docker build
+
+FROM base AS ot-efr32-dev
 ARG BUILD_DATE
 LABEL build_date=${BUILD_DATE}
 
@@ -34,8 +40,13 @@ RUN mkdir ${SLC_INSTALL_DIR} && \
       ./script/bootstrap silabs
 
 
+# Change workdir to root temporarily
+WORKDIR /
+
 # Clone repo for convenience
 ARG REPO_URL="https://github.com/openthread/ot-efr32"
-WORKDIR /
+ENV repo_dir="/ot-efr32"
 RUN rm -rf ${repo_dir} && git clone ${REPO_URL} ${repo_dir}
+
+# Change workdir back to repo
 WORKDIR ${repo_dir}

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,25 @@
+ARG BASE_IMAGE='ubuntu:22.04'
+FROM ${BASE_IMAGE} as base
+
+ENV TZ="America/New_York"
+ENV repo_dir="/ot-efr32"
+WORKDIR ${repo_dir}
+
+# Install packages
+RUN apt-get update && \
+      apt-get -y install --no-install-recommends \
+      sudo \
+      tzdata \
+      && rm -rf /var/lib/apt/lists/*
+
+# Copy scripts
+COPY  ./script/bootstrap \
+      ./script/
+
+# Install system packages and ARM toolchain
+RUN ./script/bootstrap packages && rm -rf /var/lib/apt/lists/*
+RUN ./script/bootstrap arm_toolchain
+
+# Install Python packages
+COPY ./requirements.txt .
+RUN ./script/bootstrap python

--- a/docker/ot-efr32-dev.Dockerfile
+++ b/docker/ot-efr32-dev.Dockerfile
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE='siliconlabsinc/ot-efr32-dev:base'
+
+FROM ${BASE_IMAGE} AS ot-efr32-dev
+
+COPY  ./script/bootstrap_silabs \
+      ./script/
+ENV SLC_INSTALL_DIR=/opt/slc_cli
+RUN mkdir ${SLC_INSTALL_DIR} && \
+      ./script/bootstrap silabs
+
+
+# Change workdir to root temporarily
+WORKDIR /
+
+# Clone repo for convenience
+ARG REPO_URL="https://github.com/openthread/ot-efr32"
+ENV repo_dir="/ot-efr32"
+RUN rm -rf ${repo_dir} && git clone ${REPO_URL} ${repo_dir}
+
+# Change workdir back to repo
+WORKDIR ${repo_dir}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -48,6 +48,7 @@ install_packages_apt()
     # Install dependencies
     sudo apt-get update
     apt_packages=(
+        ccache
         coreutils
         git
         git-lfs
@@ -77,6 +78,7 @@ install_packages_brew()
     echo 'Installing script dependencies...'
 
     brew_packages=(
+        ccache
         coreutils
         git
         git-lfs

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -124,13 +124,15 @@ install_arm_toolchain()
 {
     local url=${1-"https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz"}
     local extract_dir=${2-"arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi"}
+    local toolchain_dir=${3-""}
 
-    local toolchain_dir
-    # Link if root
-    if [ "$EUID" -eq 0 ]; then
-        toolchain_dir=/opt
-    else
-        toolchain_dir="${HOME}/.local"
+    # If toolchain_dir is not provided, use /opt if root, else use ~/.local
+    if [ -z "${toolchain_dir}" ]; then
+        if [ "$EUID" -eq 0 ]; then
+            toolchain_dir=/opt
+        else
+            toolchain_dir="${HOME}/.local"
+        fi
     fi
 
     # Check if the toolchain is already present at the desired location

--- a/script/build
+++ b/script/build
@@ -89,6 +89,12 @@ OT_OPTIONS=(
     "-DOT_EXTERNAL_HEAP=ON"
     "-DOT_SLAAC=ON"
 )
+
+# Check if ccache is installed and use it if available
+if command -v ccache >/dev/null; then
+    OT_OPTIONS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+    OT_OPTIONS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+fi
 readonly OT_OPTIONS
 
 generate()

--- a/script/build_example_apps
+++ b/script/build_example_apps
@@ -59,6 +59,12 @@ OT_OPTIONS=(
     "-DOT_PING_SENDER=ON"
     "-DOT_SLAAC=ON"
 )
+
+# Check if ccache is installed and use it if available
+if command -v ccache >/dev/null; then
+    OT_OPTIONS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+    OT_OPTIONS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+fi
 readonly OT_OPTIONS
 
 die()

--- a/script/generate
+++ b/script/generate
@@ -91,7 +91,7 @@ trust_sdk_and_extensions()
     set -x
 
     # Trust the Gecko SDK submodule
-    run_slc -v 1 signature trust --sdk "${sdk_dir}" -data "${openthread_slc_data}"
+    run_slc --daemon -v 1 signature trust --sdk "${sdk_dir}" -data "${openthread_slc_data}"
 
     # Ensure GSDK extension folder exists
     mkdir -p "${sdk_dir}/extension"
@@ -138,7 +138,7 @@ trust_sdk_and_extensions()
         fi
 
         # Trust the extension
-        run_slc -v 1 signature trust --sdk "${sdk_dir}" -extpath "${extension_symlink}" -data "${openthread_slc_data}"
+        run_slc --daemon -v 1 signature trust --sdk "${sdk_dir}" -extpath "${extension_symlink}" -data "${openthread_slc_data}"
     done
 
     ls -alh "${sdk_dir}/extension"
@@ -215,10 +215,9 @@ generate()
     echo "======================================================================"
     set -x
 
-    run_slc -v 1 generate \
+    run_slc --daemon -v 1 generate \
         -data "${openthread_slc_data?}" \
         --sdk="${sdk_dir?}" \
-        --clear-cache \
         --project-file="${slcp}" \
         --project-name="${project_name}" \
         --output-type=makefile \


### PR DESCRIPTION
# Summary of changes
- `slc`
  - Remove the `--clear-cache` flag to leverage SDK cache
  - Switch to using daemon-mode. Reduces `slc` startup time
- Add [`ccache`](https://ccache.dev/) to build scripts for potential build speedups. See more below
- GitHub Actions
  - Only pull required LFS files
  - Cache ARM Toolchain between builds

---

# [CCache](https://ccache.dev/)

When building with no compiler cache, the build proceeds as normal and takes a normal amount of time. For the `Build/arm-gcc-*` workflows, it usually takes ~20-30 min for the workflow to run completely. 

**Example:** `Build/arm-gcc-12.2.Rel1` (no compiler cache)

> If you examine [this](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723) run, you can see during the setup, there's no cache found [(log here)](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723#step:5:14). Looking at the [`ccache` statistics](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723#step:24:11) during teardown, you can see there was a very low cache hit rate.
> 
> `ccache` hits: **2.05 %**
> Time spent in `Build` step: **22m 22s**

**Example:** `Build/arm-gcc-12.2.Rel1` (with compiler cache)

> During this second run, [a compiler cache was located](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308127890/job/25620883929?pr=723#step:5:17) and added to the workspace.  This speedup is also reflected in the [`ccache` statistics](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308127890/job/25620883929?pr=723#step:24:11).
> 
> `ccache` hits: **99.46 %**
> Time spent in `Build` step: **2m 52s**

These performance gains are not limited to GitHub actions builds. CCache has been added to the `script/build` and `script/build-example-apps` scripts, meaning builds on development machines will also benefit from the same speedup potential.

One thing to note is that `ccache` will bring the most benefit when iterating on changes. Of course, the speedup will be reduced in scenarios where the cache cannot be leveraged, including but not limited to the first build when building for a board you haven't built before, switching branches, or making any wide-reaching changes.